### PR TITLE
Use `indicatif` to display progress bar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "4", default-features = false, features = ["cargo", "color", 
 crypto-hash = "0.3"
 futures = "0.3.7"
 hex = { version = "0.4", features = ["serde"] }
+indicatif = "0.17"
 memmap2 = "0.9"
 num-format = "0.4"
 parking_lot = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_derive = "1.0.194"
 serde_json = "1.0.110"
 tokio = { version = "1.21", features = ["full"] }
 tracing = "0.1.29"
+tracing-indicatif = "0.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 url = "2"
 walkdir = "2.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,9 +365,14 @@ async fn download_versions(config: &Config, versions: Vec<CrateVersions>) -> any
     let pb_style =
         ProgressStyle::with_template("{bar:60} ({pos}/{len}, ETA {eta}) {wide_msg}").unwrap();
 
+    let num_versions = versions
+        .iter()
+        .map(|krate| krate.versions.len())
+        .sum::<usize>();
+
     let span = Span::current();
     span.pb_set_style(&pb_style);
-    span.pb_set_length(versions.len() as u64);
+    span.pb_set_length(num_versions as u64);
 
     let iter = versions.iter().flat_map(|krate| {
         let dir = dir_for_crate(&config.output_path, &krate.name);


### PR DESCRIPTION
<img width="797" alt="Bildschirmfoto 2024-06-04 um 16 00 42" src="https://github.com/dtolnay/get-all-crates/assets/141300/b91e8e6b-18e2-4fdb-a331-08e91b0ad33f">

This PR adds a progress bar to the CLI output based on the [indicatif](https://github.com/console-rs/indicatif) crate.

I'm not a huge fan of the `pb.suspend()` calls, but I'm not aware of good alternatives. https://github.com/emersonford/tracing-indicatif could potentially help, but I don't have any experience with that crate yet.