### PR TITLE
Add `size` field to log output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/dtolnay/get-all-crates"
 [dependencies]
 anyhow = "1.0.79"
 bytes = "1"
+bytesize = "1"
 clap = { version = "4", default-features = false, features = ["cargo", "color", "deprecated", "derive", "help", "std", "usage"] }
 crypto-hash = "0.3"
 futures = "0.3.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod crateversion;
 use crate::crateversion::{Checksum, CrateVersion};
 use anyhow::bail;
 use bytes::Bytes;
+use bytesize::ByteSize;
 use clap::Parser;
 use crypto_hash::{Algorithm, Hasher};
 use futures::stream::StreamExt;
@@ -347,11 +348,13 @@ async fn download_version(
     }
 
     let body = resp.bytes().await?;
+    let size = ByteSize(body.len() as u64);
 
     info!(
         crate = %name,
         version = %vers.version,
         elapsed = ?millis(req_begin.elapsed()),
+        %size,
     );
 
     Ok(Some(Download {


### PR DESCRIPTION
This gives a bit more context on why the `elapsed` field is sometimes showing higher numbers for some crates.

Example:

```
 INFO crate=gmp-mpfr-sys version=1.0.6 elapsed=23.003s size=4.6 MB
 INFO crate=gmsm version=0.0.2 elapsed=401ms size=7.9 KB
 INFO crate=gmsm version=0.0.3 elapsed=372ms size=7.9 KB
 INFO crate=gmsm version=0.0.5 elapsed=446ms size=17.1 KB
```