### PR TITLE
Dependents filter and dry-run option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -285,28 +285,31 @@ fn get_all_crate_versions(config: &Config) -> anyhow::Result<AllCrateVersions> {
                     Err(err) => return error!(?path, "{},", err),
                 };
                 let name = &vers.name;
-                let output_dir = dir_for_crate(&config.output_path, name);
-                if let Err(err) = fs::create_dir_all(&output_dir) {
-                    error!(directory = ?output_dir, %err, "failed to create");
-                }
-                vers.versions.retain(|vers| {
-                    let path = output_dir.join(format!("{}-{}.crate", name, vers.version));
-                    match path.try_exists() {
-                        Ok(true) => {
-                            if config.verify {
-                                if let Err(err) = verify_checksum(&path, vers.checksum) {
-                                    error!(?path, "{},", err);
-                                }
-                            }
-                            false
-                        }
-                        Ok(false) => true,
-                        Err(err) => {
-                            error!(?path, "{},", err);
-                            false
-                        }
+                // Create output dir only if there are any applicable crate versions.
+                if !config.dry_run && !vers.versions.is_empty() {
+                    let output_dir = dir_for_crate(&config.output_path, name);
+                    if let Err(err) = fs::create_dir_all(&output_dir) {
+                        error!(directory = ?output_dir, %err, "failed to create");
                     }
-                });
+                    vers.versions.retain(|vers| {
+                        let path = output_dir.join(format!("{}-{}.crate", name, vers.version));
+                        match path.try_exists() {
+                            Ok(true) => {
+                                if config.verify {
+                                    if let Err(err) = verify_checksum(&path, vers.checksum) {
+                                        error!(?path, "{},", err);
+                                    }
+                                }
+                                false
+                            }
+                            Ok(false) => true,
+                            Err(err) => {
+                                error!(?path, "{},", err);
+                                false
+                            }
+                        }
+                    });
+                }
                 if !vers.versions.is_empty() {
                     crate_versions.lock().push(vers);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,10 @@ struct Config {
     #[arg(long, requires = "dependency")]
     dependency_version: Option<Version>,
 
+    /// Whether to get versions where `dependency` is only a dev dependency
+    #[arg(long, requires = "dependency")]
+    include_dev_dependencies: bool,
+
     /// Limit number of concurrent requests in flight
     #[arg(short = 'j', value_name = "INT", default_value = "50")]
     max_concurrent_requests: NonZeroU32,
@@ -135,6 +139,7 @@ fn get_crate_versions(path: &Path, config: &Config) -> anyhow::Result<CrateVersi
     struct LenientDependency<'a> {
         name: &'a str,
         req: &'a str,
+        kind: &'a str,
     }
 
     #[derive(Deserialize)]
@@ -217,6 +222,7 @@ fn get_crate_versions(path: &Path, config: &Config) -> anyhow::Result<CrateVersi
                             }
                         })
                         .unwrap_or(true)
+                    && (config.include_dev_dependencies || d.kind == "normal")
             })
         } else {
             true

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,10 @@ struct Config {
     /// Verify checksum of all previously downloaded crates
     #[arg(long)]
     verify: bool,
+
+    /// Whether to actually create download directories and download crates
+    #[arg(long)]
+    dry_run: bool,
 }
 
 fn setup_tracing() {
@@ -495,13 +499,17 @@ fn main() -> anyhow::Result<()> {
         .vec
         .sort_unstable_by(|a, b| cmp_ignore_ascii_case(&a.name, &b.name));
 
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()?;
-
-    rt.block_on(async {
-        download_versions(&config, versions).await?;
-        info!("finished in {:?}", millis(begin.elapsed()));
+    if config.dry_run {
         Ok(())
-    })
+    } else {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()?;
+
+        rt.block_on(async {
+            download_versions(&config, versions).await?;
+            info!("finished in {:?}", millis(begin.elapsed()));
+            Ok(())
+        })
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use memmap2::Mmap;
 use num_format::Locale;
 use parking_lot::Mutex;
 use rayon::ThreadPoolBuilder;
-use semver::Version;
+use semver::{Version, VersionReq};
 use serde::de::{Deserialize, Deserializer, Visitor};
 use serde_derive::Deserialize;
 use std::cmp::Ordering;
@@ -64,6 +64,15 @@ struct Config {
     /// Only get highest non-prerelease non-yanked version of each crate
     #[arg(long)]
     latest: bool,
+
+    /// Only get versions depending on the following crate
+    #[arg(long)]
+    dependency: Option<String>,
+
+    // TODO: Make these options dependent.
+    /// Only get versions depending on the folling version of the specified dependency
+    #[arg(long)]
+    dependency_version: Option<Version>,
 
     /// Limit number of concurrent requests in flight
     #[arg(short = 'j', value_name = "INT", default_value = "50")]
@@ -120,12 +129,19 @@ fn verify_checksum(crate_file_path: &Path, expected_checksum: Checksum) -> io::R
 
 fn get_crate_versions(path: &Path, config: &Config) -> anyhow::Result<CrateVersions> {
     #[derive(Deserialize)]
+    struct LenientDependency<'a> {
+        name: &'a str,
+        req: &'a str,
+    }
+
+    #[derive(Deserialize)]
     struct LenientCrateVersion<'a> {
         name: &'a str,
         #[serde(rename = "vers")]
         version: ProbablyVersion,
         #[serde(rename = "cksum", with = "hex")]
         checksum: Checksum,
+        deps: Vec<LenientDependency<'a>>,
         yanked: bool,
     }
 
@@ -183,10 +199,32 @@ fn get_crate_versions(path: &Path, config: &Config) -> anyhow::Result<CrateVersi
                 continue;
             }
         };
-        vec.push(CrateVersion {
-            version,
-            checksum: line.checksum,
-        });
+
+        let version_matches = if let Some(ref dependency) = config.dependency {
+            line.deps.iter().any(|d| {
+                d.name == dependency
+                    && config
+                        .dependency_version
+                        .as_ref()
+                        .map(|version| match VersionReq::parse(d.req) {
+                            Ok(req) => req.matches(version),
+                            Err(e) => {
+                                warn!(version = %version, ?path, "{}", e);
+                                true
+                            }
+                        })
+                        .unwrap_or(true)
+            })
+        } else {
+            true
+        };
+
+        if version_matches {
+            vec.push(CrateVersion {
+                version,
+                checksum: line.checksum,
+            });
+        }
     }
 
     if config.latest && !vec.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,9 +69,8 @@ struct Config {
     #[arg(long)]
     dependency: Option<String>,
 
-    // TODO: Make these options dependent.
     /// Only get versions depending on the folling version of the specified dependency
-    #[arg(long)]
+    #[arg(long, requires = "dependency")]
     dependency_version: Option<Version>,
 
     /// Limit number of concurrent requests in flight


### PR DESCRIPTION
I was experimenting with introducing formally semver-breaking changes which are corner cases where I suspect nobody actually affected negatively by it or checking out how a semver-breaking migration would play out. In both cases, the dependents on crates.io can give a representative sample of code using a certain crate.

To support this case, this PR adds a filter fer dependents of a certain crate (with `--dependency`). Additionally, this filter allows to select dependencies on a certain version (with `--dependency-version`) and whether dev dependencies should be included as well (with `--include-dev-dependencies`).

And because the search alone might already give insights, this PR also adds the option `--dry-run` for skipping the actual downloads.

To give an example for downloading all non-dev dependents of serialport 4.9.0:

```console
$ cargo run -- --latest --dependency serialport --dependency-version 4.9.0 --index crates.io-index/ --out test/
``` 