### PR TITLE
Alter `--verify` to also redownload after reporting mismatches

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,8 @@ struct Config {
     max_concurrent_requests: NonZeroU32,
 
     /// Verify checksum of all previously downloaded crates
+    ///
+    /// Mismatched crates will be reported and re-downloaded.
     #[arg(long)]
     verify: bool,
 }
@@ -108,14 +110,24 @@ fn checksum(bytes: &[u8]) -> Checksum {
     checksum
 }
 
-fn verify_checksum(crate_file_path: &Path, expected_checksum: Checksum) -> io::Result<()> {
+enum ChecksumVerification {
+    Match,
+    Mismatch,
+}
+
+fn verify_checksum(
+    crate_file_path: &Path,
+    expected_checksum: Checksum,
+) -> io::Result<ChecksumVerification> {
     let actual_checksum = match File::open(crate_file_path)? {
         file => checksum(&unsafe { Mmap::map(&file) }?),
     };
     if expected_checksum != actual_checksum {
         error!(path = ?crate_file_path, "checksum mismatch");
+        Ok(ChecksumVerification::Mismatch)
+    } else {
+        Ok(ChecksumVerification::Match)
     }
-    Ok(())
 }
 
 fn get_crate_versions(path: &Path, config: &Config) -> anyhow::Result<CrateVersions> {
@@ -253,11 +265,17 @@ fn get_all_crate_versions(config: &Config) -> anyhow::Result<AllCrateVersions> {
                     match path.try_exists() {
                         Ok(true) => {
                             if config.verify {
-                                if let Err(err) = verify_checksum(&path, vers.checksum) {
-                                    error!(?path, "{},", err);
+                                match verify_checksum(&path, vers.checksum) {
+                                    Ok(ChecksumVerification::Match) => false,
+                                    Ok(ChecksumVerification::Mismatch) => true,
+                                    Err(err) => {
+                                        error!(?path, "{},", err);
+                                        true
+                                    }
                                 }
+                            } else {
+                                false
                             }
-                            false
                         }
                         Ok(false) => true,
                         Err(err) => {


### PR DESCRIPTION
I'm guessing you might not want this, given it changes the behaviour of `--verify`, but it was something I needed in a world where there are a lot more crate versions now deleted and recreated after [RFC 3660](https://rust-lang.github.io/rfcs/3660-crates-io-crate-deletions.html) was implemented. Feel free to close this if it's not useful to you.